### PR TITLE
SheetSync integration: Plaid -> Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ My ideal personal accounting system would
 
 | System      | Start   | Stop    | Double-Entry | Open    | SQL | Web UI | Bank/Card Sync |
 | ----------- | ------- | ------- | ------------ | ------- | --- | ------ | -------------- |
+| Sheetsync   | 2023-   |         | **NO**       | Web API | NO  | yes    | yes            |
 | LunchMoney  | 2021-   |         | **NO**       | Web API | NO  | yes    | yes            |
 | GnuCash     | 2010-06 |         | yes          | yes     | yes | **NO** | some           |
 | Mint        | 2011?   | 2012-02 | **NO**       | NO\*    | NO  | yes    | yes            |

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "prettier": "^2.8.4",
     "typescript": "^4.8.4"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@agoric/eslint-config": "^0.3.3",
     "@agoric/eslint-plugin": "^0.2.3",
     "@endo/eslint-config": "^0.5.1",
+    "@google/clasp": "^2.4.2",
     "@types/better-sqlite3": "^7.6.1",
     "@types/node": "^14.14.7",
     "@typescript-eslint/parser": "^4.21.0",

--- a/packages/brcal/src/split_detail.sql
+++ b/packages/brcal/src/split_detail.sql
@@ -32,7 +32,7 @@ left join accounts a4
 
 DROP VIEW IF EXISTS split_detail;
 create view split_detail as
-select tx.post_date, tx.description
+select date(tx.post_date) post_date, tx.description
      , (s.value_num * 1.0 / s.value_denom) as amount
      , s.memo
      , a.code

--- a/packages/brcal/src/split_detail.sql
+++ b/packages/brcal/src/split_detail.sql
@@ -33,7 +33,7 @@ left join accounts a4
 DROP VIEW IF EXISTS split_detail;
 create view split_detail as
 select tx.post_date, tx.description
-     , (s.value_num / s.value_denom) as amount
+     , (s.value_num * 1.0 / s.value_denom) as amount
      , s.memo
      , a.code
      , a.path

--- a/packages/lm-sync/package.json
+++ b/packages/lm-sync/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "push-txids": "node src/sheetsAccess.js",
     "start": "node src/server.js"
   },
   "type": "module",

--- a/packages/lm-sync/package.json
+++ b/packages/lm-sync/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "push-txids": "node src/sheetsAccess.js",
-    "pull-categories": "node src/sheetsAccess.js --uncat",
+    "push-txids": "node src/sheetsAccess.js --push-txids",
+    "pull-categories": "node src/sheetsAccess.js --pull-cats",
     "start": "node src/server.js"
   },
   "type": "module",

--- a/packages/lm-sync/package.json
+++ b/packages/lm-sync/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "push-txids": "node src/sheetsAccess.js",
+    "pull-categories": "node src/sheetsAccess.js --uncat",
     "start": "node src/server.js"
   },
   "type": "module",

--- a/packages/lm-sync/package.json
+++ b/packages/lm-sync/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "node src/server.js"
   },
+  "type": "module",
   "dependencies": {
     "better-sqlite3": "^7.6.2",
     "body-parser": "^1.20.1",

--- a/packages/lm-sync/package.json
+++ b/packages/lm-sync/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "better-sqlite3": "^7.6.2",
     "body-parser": "^1.20.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "google-spreadsheet": "^3.3.0"
   },
   "devDependencies": {
     "@agoric/eslint-config": "^0.3.3",

--- a/packages/lm-sync/src/gcORM.js
+++ b/packages/lm-sync/src/gcORM.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+/** @typedef {import('better-sqlite3').Database} SqliteDB */
+
+const { freeze, keys } = Object;
+
+/**
+ * @param {string[]} fields
+ * @param {string} [sep]
+ */
+const clause = (fields, sep = ', ') =>
+  fields.map(n => `${n} = :${n}`).join(sep);
+
+/** @param {SqliteDB} db */
+export const makeORM = db => {
+  const self = freeze({
+    query: (table, keyFields = {}) => {
+      const stmt = db.prepare(`
+      select * from ${table}
+      where ${
+        keys(keyFields).length > 0
+          ? clause([...keys(keyFields)], ' and ')
+          : '1=1'
+      }
+    `);
+      return stmt.all(keyFields);
+    },
+    /**
+     * @param {string} table
+     * @param {Record<string, unknown>} keyFields
+     */
+    lookup: (table, keyFields) =>
+      freeze({
+        get: () => {
+          const stmt = db.prepare(`
+            select * from ${table}
+            where ${clause([...keys(keyFields)], ' and ')}
+          `);
+          return stmt.get(keyFields);
+        },
+        /** @param {Record<string, unknown>} dataFields */
+        update: dataFields => {
+          const stmt = db.prepare(`
+            update ${table}
+            set ${clause([...keys(dataFields)])}
+            where ${clause([...keys(keyFields)], ' and ')}
+          `);
+          stmt.run({ ...dataFields, ...keyFields });
+        },
+      }),
+    /**
+     * @param {string} table
+     * @param {Record<string, unknown>} fields
+     */
+    insert: (table, fields) => {
+      const names = [...keys(fields)];
+      const params = names.map(n => `:${n}`).join(', ');
+      const stmt = db.prepare(`
+        insert into ${table} (${names.join(', ')}) values (${params})`);
+      stmt.run(fields);
+    },
+    /**
+     * @param {string} table
+     * @param {Record<string, unknown>} keyFields
+     * @param {Record<string, unknown>} dataFields
+     */
+    upsert: (table, keyFields, dataFields) => {
+      const it = self.lookup(table, keyFields);
+      const v = it.get();
+      if (v) {
+        it.update(dataFields);
+        return;
+      }
+      self.insert(table, { ...keyFields, ...dataFields });
+    },
+  });
+  return self;
+};

--- a/packages/lm-sync/src/server.js
+++ b/packages/lm-sync/src/server.js
@@ -8,6 +8,7 @@
 // @ts-check
 /* global __dirname */
 import bodyParser from 'body-parser';
+import { makeORM } from './gcORM.js';
 
 const loc = /** @type {const} */ ({
   home: '/',
@@ -44,79 +45,6 @@ const { freeze, keys } = Object;
 
 const fail = (/** @type {string} */ reason) => {
   throw Error(reason);
-};
-
-/**
- * @param {string[]} fields
- * @param {string} [sep]
- */
-const clause = (fields, sep = ', ') =>
-  fields.map(n => `${n} = :${n}`).join(sep);
-
-/** @param {SqliteDB} db */
-export const makeORM = db => {
-  const self = freeze({
-    query: (table, keyFields = {}) => {
-      const stmt = db.prepare(`
-      select * from ${table}
-      where ${
-        keys(keyFields).length > 0
-          ? clause([...keys(keyFields)], ' and ')
-          : '1=1'
-      }
-    `);
-      return stmt.all(keyFields);
-    },
-    /**
-     * @param {string} table
-     * @param {Record<string, unknown>} keyFields
-     */
-    lookup: (table, keyFields) =>
-      freeze({
-        get: () => {
-          const stmt = db.prepare(`
-            select * from ${table}
-            where ${clause([...keys(keyFields)], ' and ')}
-          `);
-          return stmt.get(keyFields);
-        },
-        /** @param {Record<string, unknown>} dataFields */
-        update: dataFields => {
-          const stmt = db.prepare(`
-            update ${table}
-            set ${clause([...keys(dataFields)])}
-            where ${clause([...keys(keyFields)], ' and ')}
-          `);
-          stmt.run({ ...dataFields, ...keyFields });
-        },
-      }),
-    /**
-     * @param {string} table
-     * @param {Record<string, unknown>} fields
-     */
-    insert: (table, fields) => {
-      const names = [...keys(fields)];
-      const params = names.map(n => `:${n}`).join(', ');
-      const stmt = db.prepare(`
-        insert into ${table} (${names.join(', ')}) values (${params})`);
-      stmt.run(fields);
-    },
-    /**
-     * @param {string} table
-     * @param {Record<string, unknown>} keyFields
-     * @param {Record<string, unknown>} dataFields
-     */
-    upsert: (table, keyFields, dataFields) => {
-      const it = self.lookup(table, keyFields);
-      const v = it.get();
-      if (v) {
-        it.update(dataFields);
-        return;
-      }
-      self.insert(table, { ...keyFields, ...dataFields });
-    },
-  });
-  return self;
 };
 
 const firstSystemdFD = 3;

--- a/packages/lm-sync/src/server.js
+++ b/packages/lm-sync/src/server.js
@@ -56,6 +56,17 @@ const clause = (fields, sep = ', ') =>
 /** @param {SqliteDB} db */
 export const makeORM = db => {
   const self = freeze({
+    query: (table, keyFields = {}) => {
+      const stmt = db.prepare(`
+      select * from ${table}
+      where ${
+        keys(keyFields).length > 0
+          ? clause([...keys(keyFields)], ' and ')
+          : '1=1'
+      }
+    `);
+      return stmt.all(keyFields);
+    },
     /**
      * @param {string} table
      * @param {Record<string, unknown>} keyFields

--- a/packages/lm-sync/src/server.js
+++ b/packages/lm-sync/src/server.js
@@ -7,7 +7,7 @@
 /* eslint-disable no-continue */
 // @ts-check
 /* global __dirname */
-const bodyParser = require('body-parser');
+import bodyParser from 'body-parser';
 
 const loc = /** @type {const} */ ({
   home: '/',
@@ -54,7 +54,7 @@ const clause = (fields, sep = ', ') =>
   fields.map(n => `${n} = :${n}`).join(sep);
 
 /** @param {SqliteDB} db */
-const makeORM = db => {
+export const makeORM = db => {
   const self = freeze({
     /**
      * @param {string} table
@@ -297,7 +297,7 @@ const main = ({ env, path, express, openSqlite }) => {
 };
 
 /* global require, module, process */
-if (require.main === module) {
+if (typeof require !== 'undefined' && require.main === module) {
   main({
     env: process.env,
     // eslint-disable-next-line global-require

--- a/packages/lm-sync/src/sheetsAccess.js
+++ b/packages/lm-sync/src/sheetsAccess.js
@@ -1,0 +1,128 @@
+// @ts-check
+
+// based on
+// https://github.com/Agoric/testnet-notes/blob/main/subm/src/sheetAccess.js
+// 8dbbe50 on Dec 23, 2021
+
+/**
+ * @param {GoogleSpreadsheetWorksheet} sheet
+ * @param {string | number} key
+ * @throws on not found
+ */
+const lookup = async (sheet, key) => {
+  // load primary key column
+  // @ts-expect-error types are wrong?
+  await sheet.loadCells({
+    startColumnIndex: 0,
+    endColumnIndex: 1,
+  });
+
+  let rowIndex = 1;
+  for (; rowIndex < sheet.rowCount; rowIndex += 1) {
+    const { value } = sheet.getCell(rowIndex, 0);
+    if (value === null) throw RangeError(`${key}`); // empty row: end of data
+    if (key === value) {
+      break;
+    }
+  }
+  if (rowIndex === sheet.rowCount) throw RangeError(`${key}`);
+  const [row] = await sheet.getRows({ offset: rowIndex - 1, limit: 1 });
+  if (!row) throw TypeError('should not happen');
+  return row;
+};
+
+/**
+ * @param {GoogleSpreadsheetWorksheet} sheet
+ * @param {string | number} key
+ * @param {Record<string, string | number>} record
+ * @typedef {import('google-spreadsheet').GoogleSpreadsheetWorksheet} GoogleSpreadsheetWorksheet
+ */
+const upsert = async (sheet, key, record) => {
+  let row;
+  try {
+    row = await lookup(sheet, key);
+  } catch (_notFound) {
+    // ignore
+  }
+  if (row) {
+    Object.assign(row, record);
+    // @ts-expect-error types are wrong?
+    // docs clearly show a raw option
+    // https://theoephraim.github.io/node-google-spreadsheet/#/classes/google-spreadsheet-row?id=fn-save
+    await row.save({ raw: true });
+  } else {
+    row = await sheet.addRow(record);
+  }
+  return row;
+};
+
+/** @param {string} message */
+const fail = message => {
+  throw Error(message);
+};
+
+/**
+ * @param {Record<string, string | undefined>} env
+ * @returns {Record<string, string>}
+ */
+const makeConfig = env =>
+  /** @ts-expect-error cast */
+  new Proxy(env, {
+    get(_t, name, _r) {
+      if (typeof name !== 'string') throw RangeError(String(name));
+      const out = env[name] || fail(`missing ${String(name)}`);
+      return out;
+    },
+    set(_t, _p, _v) {
+      throw Error('read-only');
+    },
+  });
+
+/**
+ * @param {string[]} _argv
+ * @param {Record<string, string | undefined>} env
+ * @param {Object} io
+ * @param {typeof import('fs/promises')} io.fsp
+ * @param {typeof import('google-spreadsheet').GoogleSpreadsheet} io.GoogleSpreadsheet
+ */
+const integrationTest = async (_argv, env, { fsp, GoogleSpreadsheet }) => {
+  const config = makeConfig(env);
+  const creds = await fsp
+    .readFile(config.PROJECT_CREDS, 'utf-8')
+    .then(s => JSON.parse(s));
+
+  // Initialize the sheet - doc ID is the long id in the sheets URL
+  const doc = new GoogleSpreadsheet(env.SHEET1_ID);
+
+  // Initialize Auth - see https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication
+  await doc.useServiceAccountAuth(creds);
+
+  await doc.loadInfo(); // loads document properties and worksheets
+
+  const sheet = doc.sheetsByIndex[0]; // or use doc.sheetsById[id] or doc.sheetsByTitle[title]
+  console.log({
+    doc: { title: doc.title },
+    sheet0: { title: sheet.title, rowCount: sheet.rowCount },
+  });
+
+  //   await upsert(sheet, '358096357862408195', {
+  //     userID: '358096357862408195',
+  //     email: 'dckc@agoric.com',
+  //   });
+};
+
+/* global require, process */
+if (require.main === module) {
+  integrationTest(
+    process.argv.slice(2),
+    { ...process.env },
+    {
+      fsp: require('fs/promises'),
+      // eslint-disable-next-line global-require
+      GoogleSpreadsheet: require('google-spreadsheet').GoogleSpreadsheet, // please excuse CJS
+    },
+  ).catch(err => console.error(err));
+}
+
+/* global module */
+module.exports = { lookup, upsert };

--- a/packages/lm-sync/src/sheetsAccess.js
+++ b/packages/lm-sync/src/sheetsAccess.js
@@ -299,6 +299,16 @@ const updateGCFromSC = async (sc, gc, { offset = 0, limit = 3000 } = {}) => {
         code,
       },
     );
+    gc.upsert(
+      'splits',
+      { guid: detail.guid },
+      { account_guid: acct.guid, memo: stx.memo },
+    );
+    gc.upsert(
+      'transactions',
+      { guid: detail.tx_guid },
+      { description: stx.Description },
+    );
   }
 };
 

--- a/packages/sync26/amazonSync.js
+++ b/packages/sync26/amazonSync.js
@@ -1,0 +1,40 @@
+
+function AmazonLookup(tx) {
+  console.warn('AMBIENT: SpreadsheetApp');
+  const doc = SpreadsheetApp.getActive()
+
+  const { records: orders } = getSheetRecords(doc.getSheetByName('Amazon Orders'));
+  const sameAmount = orders.filter(o => o['Total Charged'] === -tx.Amount)
+  const ok = sameAmount.filter(o => {
+    const delta = daysBetween(o['Shipment Date'], tx.Date);
+    return delta >= 0 && delta <= 3;
+  });
+  // console.log('amount and date', ok)
+  if (ok.length < 1) {
+    throw Error(`no matches`)
+  }
+  if (ok.length > 1) {
+    throw Error(`too many matches: ${ok.length}`)
+  }
+  const [it] = ok;
+
+  const { records: recentItems } = getSheetRecords(doc.getSheetByName('Amazon Items'));
+  const txItems = recentItems.filter(item => item['Order ID'] === it['Order ID']);
+  const titles = txItems.map(i => i.Title);
+  const memo = JSON.stringify([titles, {orderId: it['Order ID']}])
+  const edits = { memo }
+  console.log(tx.Date, tx.Amount, edits);
+  return edits;
+}
+
+function testAmazonLookup(rowNum = 78) {
+  console.warn('AMBIENT: SpreadsheetApp');
+  const active = SpreadsheetApp.getActive();
+
+  const sheet = active.getSheetByName('Transactions (2)');
+  const cols = sheet.getLastColumn()
+  const [hd] = sheet.getRange(1, 1, 1, cols).getValues();
+  const rec = getRowRecord(sheet, rowNum, hd);
+
+  AmazonLookup(rec);
+}

--- a/packages/sync26/menu.js
+++ b/packages/sync26/menu.js
@@ -42,7 +42,10 @@ function TxLookup() {
   const rec = getRowRecord(sheet, rowNum, hd);
 
   let edits;
-  switch (rec.Description) {
+  switch (rec.Description.replace(/^Pending ~ /, '')) {
+    case 'Amazon':
+      edits = AmazonLookup(rec);
+      break;
     case 'Venmo':
       edits = VenmoLookup(rec);
       break;

--- a/packages/sync26/menu.js
+++ b/packages/sync26/menu.js
@@ -7,16 +7,24 @@ function onOpen() {
 
   // Or DocumentApp or FormApp.
   ui.createMenu('Family Finances')
-      .addItem('Tx Lookup', 'TxLookup')
-      .addSubMenu(ui.createMenu('Lunch Money')
+    .addItem('Tx Lookup', 'TxLookup')
+    .addSubMenu(
+      ui
+        .createMenu('Lunch Money')
         .addItem('Load Txs', 'loadLunchMoneyTransactions')
-        .addItem('Save Txs', 'saveLunchMoneyTransactions'))
-      .addSeparator()
-      .addSubMenu(ui.createMenu('Venmo')
-          .addItem('Load Receipts', 'LoadVenmoReceipts')
-          .addItem('Update Tx from Receipt', 'UpdateTransactionDetailsFromReceipts')
-          )
-      .addToUi();
+        .addItem('Save Txs', 'saveLunchMoneyTransactions'),
+    )
+    .addSeparator()
+    .addSubMenu(
+      ui
+        .createMenu('Venmo')
+        .addItem('Load Receipts', 'LoadVenmoReceipts')
+        .addItem(
+          'Update Tx from Receipt',
+          'UpdateTransactionDetailsFromReceipts',
+        ),
+    )
+    .addToUi();
 }
 
 function TxLookup() {
@@ -26,11 +34,11 @@ function TxLookup() {
   const active = SpreadsheetApp.getActive();
 
   const sel = active.getSelection();
-  const range = sel.getActiveRange()
-  const sheet = range.getSheet()
-  const cols = sheet.getLastColumn()
+  const range = sel.getActiveRange();
+  const sheet = range.getSheet();
+  const cols = sheet.getLastColumn();
   const [hd] = sheet.getRange(1, 1, 1, cols).getValues();
-  const rowNum = range.getRow()
+  const rowNum = range.getRow();
   const rec = getRowRecord(sheet, rowNum, hd);
 
   let edits;
@@ -39,8 +47,9 @@ function TxLookup() {
       edits = VenmoLookup(rec);
       break;
     default:
-      SpreadsheetApp.getUi()
-       .alert(`${sheet.getName()}: row ${rowNum} ???: ${values(rec)}`);
+      SpreadsheetApp.getUi().alert(
+        `${sheet.getName()}: row ${rowNum} ???: ${values(rec)}`,
+      );
       return;
   }
   // SpreadsheetApp.getUi()

--- a/packages/sync26/sheetTools.js
+++ b/packages/sync26/sheetTools.js
@@ -1,5 +1,3 @@
-
-
 function GetAllSheetNames() {
   console.warn('AMBIENT: SpreadsheetApp');
   const sheets = SpreadsheetApp.getActiveSpreadsheet().getSheets();
@@ -21,13 +19,17 @@ function getRowRecord(sheet, row, headings) {
 
 function getSheetRecords(sheet) {
   const hd = [];
-  for (let col = 1, name; (name = sheet.getRange(1, col).getValue()) > ''; col += 1) {
+  for (
+    let col = 1, name;
+    (name = sheet.getRange(1, col).getValue()) > '';
+    col += 1
+  ) {
     hd.push(name);
   }
   const data = sheet.getRange(2, 1, sheet.getLastRow(), hd.length).getValues();
   const records = [];
   for (const values of data) {
-    const entries = zip(hd, values)
+    const entries = zip(hd, values);
     const record = Object.fromEntries(entries);
     if (!record[hd[0]]) break;
     records.push(record);

--- a/packages/sync26/tradeSync3.js
+++ b/packages/sync26/tradeSync3.js
@@ -28,10 +28,10 @@ const SOURCES = { StakeTax, Osmosis, Coinbase };
 const SHEETS = { trading: MailSearch, ...SOURCES };
 
 function reset_(active, sheets = SHEETS) {
-  const { keys } = Object
+  const { keys } = Object;
   for (const name of keys(sheets)) {
     const sheet = active.getSheetByName(name);
-    console.log('clear sheet:', name)
+    console.log('clear sheet:', name);
     sheet.clear();
   }
 }
@@ -39,13 +39,18 @@ function reset_(active, sheets = SHEETS) {
 function findHd_(rows, sources = SOURCES) {
   const { entries } = Object;
   for (let ix = 0; ix < rows.length; ix++) {
-    for (const [name, { hd: [col1] }] of entries(sources)) {
+    for (const [
+      name,
+      {
+        hd: [col1],
+      },
+    ] of entries(sources)) {
       if (rows[ix][0] === col1) {
         return [name, rows[ix], rows.slice(ix + 1)];
       }
     }
   }
-  throw Error(`cannot recognize header: ${rows[0]}`)
+  throw Error(`cannot recognize header: ${rows[0]}`);
 }
 
 const zip_ = (xs, ys) => xs.map((x, ix) => [x, ys[ix]]);
@@ -59,8 +64,11 @@ function sheetRecords_(sheet) {
   return detail.map(row => fromEntries(zip_(hd, row)));
 }
 
-function parseBlockchainDate (txt = '2023-02-04 05:19:32', dateFormat = StakeTax.dateFormat) {
-  return parseDate(txt, 'GMT', dateFormat)
+function parseBlockchainDate(
+  txt = '2023-02-04 05:19:32',
+  dateFormat = StakeTax.dateFormat,
+) {
+  return parseDate(txt, 'GMT', dateFormat);
 }
 
 function byDate_(rows, source) {
@@ -73,18 +81,27 @@ function byDate_(rows, source) {
     return cells;
   });
   return withDates;
-};
+}
 
 function loadCSV_(active, att) {
   const rows = Utilities.parseCsv(att.getDataAsString());
   const [name, hd, raw] = findHd_(rows);
   console.log('loading from', att.getName(), 'into', name);
-  const source = SOURCES[name]
+  const source = SOURCES[name];
   const detail = byDate_(raw, source);
 
   const sheet = active.getSheetByName(name);
   const last = sheet.getLastRow() + 2;
-  console.log('loading', detail.length, 'rows from', att.getName(), 'into', name, 'at', last);
+  console.log(
+    'loading',
+    detail.length,
+    'rows from',
+    att.getName(),
+    'into',
+    name,
+    'at',
+    last,
+  );
   setRange(sheet, hd, detail, 1, last);
 }
 
@@ -99,7 +116,9 @@ function loadTradeAccountingMessages() {
 
   console.warn('AMBIENT: GmailApp');
   const threads = GmailApp.search(MailSearch.query);
-  const msgs = threads.flatMap(thread => thread.getMessages().filter((_m, ix) => ix <= 1));
+  const msgs = threads.flatMap(thread =>
+    thread.getMessages().filter((_m, ix) => ix <= 1),
+  );
 
   const rows = msgs.map(m => {
     const atts = m.getAttachments();
@@ -116,7 +135,10 @@ function loadTradeAccountingMessages() {
 
 function txDate_(timestamp) {
   const dateTime = timestamp.toISOString();
-  return { date_posted: dateTime.slice(0, 10), number: dateTime.slice(11, 16) + 'Z' };
+  return {
+    date_posted: dateTime.slice(0, 10),
+    number: dateTime.slice(11, 16) + 'Z',
+  };
 }
 
 /**
@@ -128,20 +150,35 @@ function txfrSplits_(records) {
   let splits = [];
   for (const record of records) {
     // TODO: fee
-    const { txid, url, timestamp,
-      sent_amount, sent_currency,
-      received_amount, received_currency,
-      exchange, wallet_address } = record;
+    const {
+      txid,
+      url,
+      timestamp,
+      sent_amount,
+      sent_currency,
+      received_amount,
+      received_currency,
+      exchange,
+      wallet_address,
+    } = record;
     const amount = sent_currency > '' ? -sent_amount : received_amount;
     const action = sent_currency > '' ? 'Sell' : 'Buy';
     const sym = sent_currency > '' ? sent_currency : received_currency;
     // TODO: price
-    const split = { action, memo: txid, account: `${sym} ${wallet_address}`, amount, sym, reconcile: 'c', url };
+    const split = {
+      action,
+      memo: txid,
+      account: `${sym} ${wallet_address}`,
+      amount,
+      sym,
+      reconcile: 'c',
+      url,
+    };
     splits.push(split);
     if (splits.length === 1) {
       const [_all, _hash, _msg] = txid.match(/([^-]+)-(.*)/);
       const dateTime = timestamp.toISOString();
-      txs.push({ ...txDate_(timestamp), description: exchange, splits })
+      txs.push({ ...txDate_(timestamp), description: exchange, splits });
     } else {
       splits = [];
       txs.at(-1).description += ` to ${exchange}`;
@@ -155,9 +192,12 @@ function txfrSplits_(records) {
  */
 function flatten_(record) {
   const { entries, fromEntries } = Object;
-  const recur = (pfx, obj) => entries(obj).flatMap(
-    ([k, v]) => (typeof(v) === 'object' && ! (v instanceof Date)) ?
-      recur(`${pfx}${k}_`, v) : [[`${pfx}${k}`, v]]);
+  const recur = (pfx, obj) =>
+    entries(obj).flatMap(([k, v]) =>
+      typeof v === 'object' && !(v instanceof Date)
+        ? recur(`${pfx}${k}_`, v)
+        : [[`${pfx}${k}`, v]],
+    );
   return fromEntries(recur('', record));
 }
 
@@ -169,7 +209,7 @@ function flattenTxs_(txs) {
       if (ix === 0) {
         records.push(flatten_({ ...rest, ...split }));
       } else {
-        records.push(flatten_(split))
+        records.push(flatten_(split));
       }
     });
   }
@@ -178,10 +218,10 @@ function flattenTxs_(txs) {
   return { records, hd, rows };
 }
 
-const max_ = xs => xs.reduce((acc, next) => next > acc ? next : acc);
+const max_ = xs => xs.reduce((acc, next) => (next > acc ? next : acc));
 const sum_ = xs => xs.reduce((acc, next) => acc + next, 0);
 const select_ = (recs, prop) => recs.map(r => r[prop]);
-const round_ = (x, d) => Number(x.toPrecision(d))
+const round_ = (x, d) => Number(x.toPrecision(d));
 
 /**
  * select max(Timestamp), Asset, sum(`Quantity Transacted`), sum(Total), sum(Fees) group by Asset")
@@ -189,10 +229,12 @@ const round_ = (x, d) => Number(x.toPrecision(d))
 function coinbaseTrades(active, since, asset = 'ATOM') {
   const coinbaseSheet = active.getSheetByName('Coinbase');
   const records = sheetRecords_(coinbaseSheet);
-  const current = records
-    .filter(r => r[Coinbase.dateColumn] >= since &&
-     /Trade/.test(r['Transaction Type']) && 
-     r.Asset === asset);
+  const current = records.filter(
+    r =>
+      r[Coinbase.dateColumn] >= since &&
+      /Trade/.test(r['Transaction Type']) &&
+      r.Asset === asset,
+  );
   const agg = {
     Timestamp: max_(select_(current, 'Timestamp')),
     quantity: sum_(select_(current, 'Quantity Transacted')),
@@ -202,12 +244,24 @@ function coinbaseTrades(active, since, asset = 'ATOM') {
 
   const reconcile = 'c';
   const tx = {
-    ...txDate_(agg.Timestamp), description: `${asset} Trade`,
+    ...txDate_(agg.Timestamp),
+    description: `${asset} Trade`,
     splits: [
-      { account: 'ATOM Wallet', action: 'Sell', amount: -agg.quantity, reconcile },
-      { account: 'USD Wallet', amount: agg.proceeds, memo: 'proceeds', reconcile },
+      {
+        account: 'ATOM Wallet',
+        action: 'Sell',
+        amount: -agg.quantity,
+        reconcile,
+      },
+      {
+        account: 'USD Wallet',
+        amount: agg.proceeds,
+        memo: 'proceeds',
+        reconcile,
+      },
       { account: 'AIE:Fees', amount: agg.fees, memo: 'Fees', reconcile },
-    ]}
+    ],
+  };
   return [tx];
 }
 
@@ -218,8 +272,9 @@ function stakeTaxTransfers(active, since) {
   const txfrs = records
     .filter(({ tx_type }) => tx_type === 'TRANSFER')
     .filter(({ [dateColumn]: dt }) => dt >= since);
-  const splits = txfrs
-    .sort((a, b) => a[dateColumn].getTime() - b[dateColumn].getTime());
+  const splits = txfrs.sort(
+    (a, b) => a[dateColumn].getTime() - b[dateColumn].getTime(),
+  );
   const txs = txfrSplits_(splits);
   return txs;
 }
@@ -232,13 +287,14 @@ function buildTradeTransactions() {
   const txs = [
     ...stakeTaxTransfers(active, since),
     ...coinbaseTrades(active, since),
-  ].sort((a, b) => `${a.date_posted} ${a.number}` > `${b.date_posted} ${b.number}`);
+  ].sort(
+    (a, b) => `${a.date_posted} ${a.number}` > `${b.date_posted} ${b.number}`,
+  );
 
   const { hd, rows } = flattenTxs_(txs);
   console.log('Transactions:', hd, rows.length);
 
   const importSheet = active.getSheetByName('tx_import');
   importSheet.clear();
-  setRange(importSheet, hd, rows)
+  setRange(importSheet, hd, rows);
 }
-


### PR DESCRIPTION
[Lunchmoney](https://lunchmoney.app/) does much of what I wanted to do by way of a web interface to my accounts via [Plaid](https://plaid.com/), but lack of thorough double-entry accounting means I'm still using [GnuCash](https://www.gnucash.org/). Plus, I use Google Sheets for all sorts of ad-hoc stuff. What about going straight from Plaid to Google Sheets? Is that a thing? Indeed it is!

 - [Sheetsync • Automatically sync your finances with your spreadsheet](https://getsheetsync.com/)
 - [Sheetsync \- Google Workspace Marketplace](https://workspace.google.com/marketplace/app/sheetsync/198068442022)

I'm pretty happy with the results of the two week free trial. Some of my goals were:

 - [x] Sync from Venmo
 - [x] Sync from Amazon
 - [x] Sync to GnuCash

## Accounts with codes

Setting up a few accounts worked as expected. I added a column for account **code** for syncing with my [GnuCash Chart of Accounts](https://www.gnucash.org/viewdoc.phtml?rev=4&lang=C&doc=help).

The Balances sheet works nicely.

## Categories with codes

Exporting my GnuCash income / expense accounts for use as Categories was straightforward:

 - 2023-02-18 14:14 659f181 feat(book_ops): accounts as categories: code, Category, Group, Type

[Sqlite recursive queries](https://www.sqlite.org/lang_with.html#recursive_common_table_expressions) are fun!

Shout-out to [DBeaver](https://dbeaver.io/), my favorite SQL IDE these days.

TODO:

 - [ ] refine 2-level account hierarchy

## Transactions: Fill in Venmo details from email

My bank reports Venmo transactions as just "Venmo". Finding the payee and memo from email is tedious, so I made a [Custom Menu](https://developers.google.com/apps-script/guides/menus) with some [Custom Functions](https://developers.google.com/apps-script/guides/sheets/functions) using Google Apps Script.

![Screenshot at 2023-02-25 22-21-34](https://user-images.githubusercontent.com/150986/221392216-7e361c26-d30a-4fce-881c-3875b0f411a6.png)

 - 2022-10-26 23:15 ab7451b feat: extract venmo receipts from gmail to sheet
 - 2022-10-28 10:22 0238e9d feate: match venmo receipts to lunchmoney transactions

Handy refs:

 - [Class Utilities  |  Apps Script  |  Google Developers](https://developers.google.com/apps-script/reference/utilities/utilities?hl=en#parseDate(String,String,String))
 - [clasp - The Apps Script CLI](https://codelabs.developers.google.com/codelabs/clasp/)

## Transactions: Fill in Amazon details from reports

Amazon provides [CSV exports of Orders and Items](https://www.tillerhq.com/how-to-download-your-amazon-order-history-report/). I import those into nearby sheets and then when I have a transaction selected, I use **Tx Lookup** to add the items to the transaction memo, which makes it easier to categorize. **Tx Lookup** will look up Amazon or Venmo depending on the Description.

![Screenshot at 2023-02-25 22-08-02](https://user-images.githubusercontent.com/150986/221392392-9b7d9c63-0d8d-4267-aa1f-2eee679c5bb8.png)

TODO:
  - [ ] if multiple rows are selected, look them all up
  - [ ] bug: doesn't handle when Amazon splits an order into multiple deliveries

## Transactions: Push GnuCash Ids to Sheetsync

This adds a `yarn push-txids` CLI tool to annotate Sheetsync transactions with GnuCash ids:

```js
/**
 * For each row that does not yet have a tx_guid,
 * look it up in split_detail by date, amount, and account code.
 * Update tx_guid and online_id in Syncsheets.
 */
export const pushTxIds = async (sc, gc, { offset, limit = 3000 } = {}) => {
```

 - 2023-02-20 17:48 d9b19fd feat: annotate Sheetsync Transactions with GnuCash tx_guid

`split_detail` is a join of the GnuCash `transactions`, `splits`, and `accounts` tables.

## Transactions: Pull Categories from Sheetsync to GnuCash

Then I use `yarn pull-categories`:

```js
/**
 * For uncategorized GnuCash transactions (account code 9001)
 * apply category from Sheetsync where available.
 */
const pullCategories = async (sc, gc, { offset = 0, limit = 3000 } = {}) => {
```

 - 2023-02-25 20:53 87ffad8 feat(lm-sync): apply SS Tx Categories to GnuCash splits

